### PR TITLE
Comment,CommentHeart 양방향 설정 및 EntityGraph 적용

### DIFF
--- a/src/main/java/com/nbc/newsfeeds/domain/comment/entity/Comment.java
+++ b/src/main/java/com/nbc/newsfeeds/domain/comment/entity/Comment.java
@@ -53,10 +53,7 @@ public class Comment extends BaseEntity {
 
 	@Column(name = "heart_count", nullable = false)
 	private Integer heartCount;
-
-	@OneToMany(mappedBy = "comment", cascade = CascadeType.ALL, orphanRemoval = true)
-	private List<CommentHeart> hearts = new ArrayList<>();
-
+	
 	public void update(String content) {
 		this.content = content;
 	}

--- a/src/main/java/com/nbc/newsfeeds/domain/comment/entity/Comment.java
+++ b/src/main/java/com/nbc/newsfeeds/domain/comment/entity/Comment.java
@@ -1,11 +1,16 @@
 package com.nbc.newsfeeds.domain.comment.entity;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import com.nbc.newsfeeds.common.audit.BaseEntity;
 import com.nbc.newsfeeds.domain.comment.code.CommentExceptionCode;
 import com.nbc.newsfeeds.domain.comment.exception.CommentException;
 import com.nbc.newsfeeds.domain.feed.entity.Feed;
+import com.nbc.newsfeeds.domain.heart.entity.CommentHeart;
 import com.nbc.newsfeeds.domain.member.entity.Member;
 
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -14,6 +19,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -47,6 +53,9 @@ public class Comment extends BaseEntity {
 
 	@Column(name = "heart_count", nullable = false)
 	private Integer heartCount;
+
+	@OneToMany(mappedBy = "comment", cascade = CascadeType.ALL, orphanRemoval = true)
+	private List<CommentHeart> hearts = new ArrayList<>();
 
 	public void update(String content) {
 		this.content = content;

--- a/src/main/java/com/nbc/newsfeeds/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/com/nbc/newsfeeds/domain/comment/repository/CommentRepository.java
@@ -1,11 +1,18 @@
 package com.nbc.newsfeeds.domain.comment.repository;
 
+import java.util.Optional;
+
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.nbc.newsfeeds.domain.comment.entity.Comment;
 
 public interface CommentRepository extends JpaRepository<Comment, Long> {
-	Page<Comment> findAllByFeedId(Long id, Pageable pageable);
+	@EntityGraph(attributePaths = {"feed"})
+	Page<Comment> findAllByFeedId(Long feedId, Pageable pageable);
+
+	@EntityGraph(attributePaths = {"feed"})
+	Optional<Comment> findWithFeedById(Long commentId);
 }

--- a/src/main/java/com/nbc/newsfeeds/domain/comment/service/CommentService.java
+++ b/src/main/java/com/nbc/newsfeeds/domain/comment/service/CommentService.java
@@ -126,11 +126,13 @@ public class CommentService {
 	@Transactional
 	public CommonResponse<CommentDetailAndUpdateResponse> updateComment(Long commentId, CommentUpdateRequest request,
 		MemberAuth authUser) {
-		Comment comment = commentRepository.findById(commentId)
+		Comment comment = commentRepository.findWithFeedById(commentId)
 			.orElseThrow(() -> new CommentException(CommentExceptionCode.COMMENT_NOT_FOUND));
 
+		Feed feed = comment.getFeed();
+
 		if (!authUser.getId().equals(comment.getMember().getId())
-			&& !authUser.getId().equals(comment.getFeed().getMember().getId())) {
+			&& !authUser.getId().equals(feed.getMember().getId())) {
 			throw new CommentException(CommentExceptionCode.UNAUTHORIZED_ACCESS);
 		}
 
@@ -138,7 +140,7 @@ public class CommentService {
 
 		CommentDetailAndUpdateResponse result = CommentDetailAndUpdateResponse.builder()
 			.commentId(comment.getId())
-			.feedId(comment.getFeed().getId())
+			.feedId(feed.getId())
 			.memberId(comment.getMember().getId())
 			.content(comment.getContent())
 			.createdAt(comment.getCreatedAt())


### PR DESCRIPTION
기존 commentRepository.findById를 사용하는 메서드 중 fetcj join이 필요한 곳은 findWIthFeedById를 사용하도록 변경

Comment엔티티에서 Feed엔티티를 연관관계 설정할 때 EAGER로 할까 했지만 EntityGraph를 사용해서 필요한곳에서만 사용하는것이 더 좋다고 판단

cascade delete를 사용하기 위해 COmment와 CommentHeart를 양방향으로 설정

CommentHeart의 @OnDelete(action = OnDeleteAction.SET_NULL) 부분 제거해주시면 될듯합니다