### PR TITLE
Refactor : 로그인 시 유저 조회 로직 수정, 비밀번호 검증 패턴 추가, 로그아웃, 탈퇴 로직 추가

### DIFF
--- a/src/main/java/com/nbc/newsfeeds/common/filter/BaseJwtTokenFilter.java
+++ b/src/main/java/com/nbc/newsfeeds/common/filter/BaseJwtTokenFilter.java
@@ -56,7 +56,7 @@ public abstract class BaseJwtTokenFilter extends OncePerRequestFilter {
 		}
 
 		if (shouldCheckBlackList() && jwtService.isBlackListed(token)) {
-			throw new FilterException(FilterExceptionCode.ALREADY_SIGN_OUT);
+			throw new FilterException(FilterExceptionCode.CANT_USE_TOKEN);
 		}
 
 		MemberAuth memberAuth = jwtService.getMemberAuth(token);

--- a/src/main/java/com/nbc/newsfeeds/common/filter/exception/FilterExceptionCode.java
+++ b/src/main/java/com/nbc/newsfeeds/common/filter/exception/FilterExceptionCode.java
@@ -13,7 +13,7 @@ public enum FilterExceptionCode implements ResponseCode {
 	TOKEN_EXPIRED(false, HttpStatus.UNAUTHORIZED, "토큰이 만료되었습니다."),
 	EMPTY_TOKEN(false, HttpStatus.UNAUTHORIZED, "헤더에 토큰을 포함하고 있지 않습니다."),
 	MALFORMED_JWT_REQUEST(false, HttpStatus.UNAUTHORIZED, "요청 형태가 잘못 되었습니다."),
-	ALREADY_SIGN_OUT(false, HttpStatus.UNAUTHORIZED, "이미 로그아웃한 유저입니다."),
+	CANT_USE_TOKEN(false, HttpStatus.UNAUTHORIZED, "사용할 수 없는 토큰입니다."),
 	INVALID_TOKEN_USAGE(false, HttpStatus.FORBIDDEN, "잘못된 유형의 토큰입니다.");
 	private final boolean success;
 	private final HttpStatus httpStatus;

--- a/src/main/java/com/nbc/newsfeeds/common/jwt/core/JwtService.java
+++ b/src/main/java/com/nbc/newsfeeds/common/jwt/core/JwtService.java
@@ -90,4 +90,8 @@ public class JwtService {
 	public boolean isTokenExpired(String token) {
 		return jwtParser.isTokenExpired(token);
 	}
+
+	public void deleteRefreshToken(String email) {
+		redisService.deleteRefreshToken(email);
+	}
 }

--- a/src/main/java/com/nbc/newsfeeds/common/util/SecurityUtils.java
+++ b/src/main/java/com/nbc/newsfeeds/common/util/SecurityUtils.java
@@ -1,0 +1,13 @@
+package com.nbc.newsfeeds.common.util;
+
+import org.springframework.security.core.context.SecurityContextHolder;
+
+public class SecurityUtils {
+	public static String getCurrentToken() {
+		return SecurityContextHolder.getContext().getAuthentication().getCredentials().toString();
+	}
+
+	public static void clearContext() {
+		SecurityContextHolder.clearContext();
+	}
+}

--- a/src/main/java/com/nbc/newsfeeds/domain/member/dto/request/MemberSignUpDto.java
+++ b/src/main/java/com/nbc/newsfeeds/domain/member/dto/request/MemberSignUpDto.java
@@ -24,6 +24,8 @@ public class MemberSignUpDto {
 
 	@NotBlank(message = "비밀번호는 필수 입력값이며 공백이 아니어야 합니다.")
 	@Size(min = 8, message = "비밀번호는 8글자 이상이어야 합니다.")
+	@Pattern(regexp = "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[!@#$%^&*()_\\-+={\\[}\\]:;\"'<,>.?/]).{8,}$",
+		message = "비밀번호는 대소문자, 숫자, 특수문자를 각각 최소 1자 이상 포함해야 합니다.")
 	private String password;
 
 	@NotNull(message = "생년월일은 필수 입력 값입니다.")

--- a/src/main/java/com/nbc/newsfeeds/domain/member/dto/request/MemberUpdateDto.java
+++ b/src/main/java/com/nbc/newsfeeds/domain/member/dto/request/MemberUpdateDto.java
@@ -4,6 +4,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -28,6 +29,8 @@ public class MemberUpdateDto {
 
 		@NotBlank(message = "신규 비밀번호는 필수 입력값이며 공백이 아니어야 합니다.")
 		@Size(min = 8, message = "신규 비밀번호는 8글자 이상이어야 합니다.")
+		@Pattern(regexp = "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[!@#$%^&*()_\\-+={\\[}\\]:;\"'<,>.?/]).{8,}$",
+			message = "비밀번호는 대소문자, 숫자, 특수문자를 각각 최소 1자 이상 포함해야 합니다.")
 		private String newPassword;
 
 		public boolean isSameAsCurrentPassword(String encodedPassword, PasswordEncoder passwordEncoder) {

--- a/src/main/java/com/nbc/newsfeeds/domain/member/event/MemberWithdrawEvent.java
+++ b/src/main/java/com/nbc/newsfeeds/domain/member/event/MemberWithdrawEvent.java
@@ -1,0 +1,13 @@
+package com.nbc.newsfeeds.domain.member.event;
+
+import com.nbc.newsfeeds.domain.member.auth.MemberAuth;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class MemberWithdrawEvent {
+	private final String accessToken;
+	private final MemberAuth memberAuth;
+}

--- a/src/main/java/com/nbc/newsfeeds/domain/member/listener/MemberEventListener.java
+++ b/src/main/java/com/nbc/newsfeeds/domain/member/listener/MemberEventListener.java
@@ -1,0 +1,29 @@
+package com.nbc.newsfeeds.domain.member.listener;
+
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import com.nbc.newsfeeds.common.jwt.core.JwtService;
+import com.nbc.newsfeeds.domain.member.event.MemberWithdrawEvent;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class MemberEventListener {
+	private final JwtService jwtService;
+
+	@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+	public void handleMemberWithdrawEvent(MemberWithdrawEvent event) {
+		try {
+			jwtService.blockAccessToken(event.getAccessToken(), event.getMemberAuth());
+
+			jwtService.deleteRefreshToken(event.getMemberAuth().getEmail());
+		} catch (Exception e) {
+			log.warn("회원 탈퇴 후 로그아웃 처리 중 오류 발생", e);
+		}
+	}
+}

--- a/src/main/java/com/nbc/newsfeeds/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/nbc/newsfeeds/domain/member/repository/MemberRepository.java
@@ -2,6 +2,7 @@ package com.nbc.newsfeeds.domain.member.repository;
 
 import java.util.Optional;
 
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.nbc.newsfeeds.domain.member.entity.Member;
@@ -11,5 +12,6 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 
 	boolean existsByNickName(String nickName);
 
-	Optional<Member> findMemberByEmail(String email);
+	@EntityGraph(attributePaths = {"roles"})
+	Optional<Member> findMemberWithRolesByEmail(String email);
 }

--- a/src/main/java/com/nbc/newsfeeds/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/nbc/newsfeeds/domain/member/repository/MemberRepository.java
@@ -13,5 +13,5 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 	boolean existsByNickName(String nickName);
 
 	@EntityGraph(attributePaths = {"roles"})
-	Optional<Member> findMemberWithRolesByEmail(String email);
+	Optional<Member> findWithRolesByEmail(String email);
 }

--- a/src/main/java/com/nbc/newsfeeds/domain/member/service/MemberService.java
+++ b/src/main/java/com/nbc/newsfeeds/domain/member/service/MemberService.java
@@ -65,7 +65,7 @@ public class MemberService {
 	 * @author 이승현
 	 */
 	public TokensDto signIn(MemberSignInDto memberSignInDto, Date date) {
-		Member member = memberRepository.findMemberWithRolesByEmail(memberSignInDto.getEmail())
+		Member member = memberRepository.findWithRolesByEmail(memberSignInDto.getEmail())
 			.orElseThrow(() -> new MemberException(MemberResponseCode.MEMBER_NOT_FOUND));
 
 		validateNotDeleted(member);

--- a/src/main/java/com/nbc/newsfeeds/domain/member/service/MemberService.java
+++ b/src/main/java/com/nbc/newsfeeds/domain/member/service/MemberService.java
@@ -6,6 +6,7 @@ import java.util.Objects;
 
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
 
 import com.nbc.newsfeeds.common.jwt.core.JwtService;
@@ -21,7 +22,6 @@ import com.nbc.newsfeeds.domain.member.entity.Member;
 import com.nbc.newsfeeds.domain.member.exception.MemberException;
 import com.nbc.newsfeeds.domain.member.repository.MemberRepository;
 
-import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 
 @Service
@@ -64,9 +64,8 @@ public class MemberService {
 	 * @return access token, refresh token
 	 * @author 이승현
 	 */
-	@Transactional
 	public TokensDto signIn(MemberSignInDto memberSignInDto, Date date) {
-		Member member = memberRepository.findMemberByEmail(memberSignInDto.getEmail())
+		Member member = memberRepository.findMemberWithRolesByEmail(memberSignInDto.getEmail())
 			.orElseThrow(() -> new MemberException(MemberResponseCode.MEMBER_NOT_FOUND));
 
 		validateNotDeleted(member);

--- a/src/test/java/com/nbc/newsfeeds/domain/member/controller/AuthControllerTest.java
+++ b/src/test/java/com/nbc/newsfeeds/domain/member/controller/AuthControllerTest.java
@@ -63,7 +63,7 @@ class AuthControllerTest {
 
 	@BeforeEach
 	void setUp() {
-		memberSignUpDto = new MemberSignUpDto("test", "test@test", "testPass",
+		memberSignUpDto = new MemberSignUpDto("test", "test@test", "Test1!@#",
 			LocalDate.now(), "01012345678");
 
 		memberDto = MemberDto.builder()
@@ -99,7 +99,7 @@ class AuthControllerTest {
 				status().isCreated(),
 				jsonPath("$.success")
 					.value(true),
-				jsonPath("$.status_code")
+				jsonPath("$.status")
 					.value(201),
 				jsonPath("$.message")
 					.value(MemberResponseCode.SUCCESS_SIGN_UP.getMessage()),
@@ -138,7 +138,7 @@ class AuthControllerTest {
 				status().isOk(),
 				jsonPath("$.success")
 					.value(true),
-				jsonPath("$.status_code")
+				jsonPath("$.status")
 					.value(200),
 				jsonPath("$.message")
 					.value(MemberResponseCode.SUCCESS_SIGN_IN.getMessage()),
@@ -164,7 +164,7 @@ class AuthControllerTest {
 				status().isOk(),
 				jsonPath("$.success")
 					.value(true),
-				jsonPath("$.status_code")
+				jsonPath("$.status")
 					.value(200),
 				jsonPath("$.message")
 					.value(MemberResponseCode.SUCCESS_SIGN_OUT.getMessage())
@@ -176,7 +176,7 @@ class AuthControllerTest {
 	@DisplayName("회원탈퇴 성공")
 	void success_withdraw() throws Exception {
 		// Given
-		when(memberService.withdraw(any(), any()))
+		when(memberService.withdraw(any(), any(), any()))
 			.thenReturn(1L);
 
 		// When
@@ -190,7 +190,7 @@ class AuthControllerTest {
 				status().isOk(),
 				jsonPath("$.success")
 					.value(true),
-				jsonPath("$.status_code")
+				jsonPath("$.status")
 					.value(200),
 				jsonPath("$.message")
 					.value(MemberResponseCode.SUCCESS_WITHDRAW.getMessage()),
@@ -216,7 +216,7 @@ class AuthControllerTest {
 				status().isOk(),
 				jsonPath("$.success")
 					.value(true),
-				jsonPath("$.status_code")
+				jsonPath("$.status")
 					.value(200),
 				jsonPath("$.message")
 					.value(MemberResponseCode.SUCCESS_REGENERATE_ACCESS_TOKEN.getMessage()),

--- a/src/test/java/com/nbc/newsfeeds/domain/member/service/MemberServiceTest.java
+++ b/src/test/java/com/nbc/newsfeeds/domain/member/service/MemberServiceTest.java
@@ -167,7 +167,7 @@ class MemberServiceTest {
 			// Given
 			given(passwordEncoder.matches(anyString(), anyString()))
 				.willReturn(true);
-			given(memberRepository.findMemberByEmail(anyString()))
+			given(memberRepository.findWithRolesByEmail(anyString()))
 				.willReturn(Optional.ofNullable(member));
 			given(tokensDto.getAccessToken())
 				.willReturn("accessToken");
@@ -192,7 +192,7 @@ class MemberServiceTest {
 		@DisplayName("로그인 실패 - 유저를 찾을 수 없음")
 		void fail_signIn_memberNotFound() {
 			// Given
-			given(memberRepository.findMemberByEmail(anyString()))
+			given(memberRepository.findWithRolesByEmail(anyString()))
 				.willReturn(Optional.empty());
 
 			// When
@@ -213,7 +213,7 @@ class MemberServiceTest {
 		@DisplayName("로그인 실패 - 탈퇴한 유저")
 		void fail_signIn_withdrawnMember() {
 			// Given
-			given(memberRepository.findMemberByEmail(anyString()))
+			given(memberRepository.findWithRolesByEmail(anyString()))
 				.willReturn(Optional.ofNullable(member.toBuilder()
 					.isDeleted(true)
 					.build()));
@@ -236,7 +236,7 @@ class MemberServiceTest {
 		@DisplayName("로그인 실패 - 비밀번호 오류")
 		void fail_signIn_wrongPassword() {
 			// Given
-			given(memberRepository.findMemberByEmail(anyString()))
+			given(memberRepository.findWithRolesByEmail(anyString()))
 				.willReturn(Optional.ofNullable(member));
 			given(passwordEncoder.matches(anyString(), anyString()))
 				.willReturn(false);

--- a/src/test/java/com/nbc/newsfeeds/domain/member/service/MemberServiceTest.java
+++ b/src/test/java/com/nbc/newsfeeds/domain/member/service/MemberServiceTest.java
@@ -19,6 +19,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
 import com.nbc.newsfeeds.common.jwt.core.JwtService;
@@ -44,6 +45,9 @@ class MemberServiceTest {
 
 	@Mock
 	private JwtService jwtService;
+
+	@Mock
+	private ApplicationEventPublisher eventPublisher;
 
 	@InjectMocks
 	private MemberService memberService;
@@ -288,7 +292,7 @@ class MemberServiceTest {
 				.willReturn(true);
 
 			// When
-			Long memberId = memberService.withdraw(memberAuth, "testPass");
+			Long memberId = memberService.withdraw(memberAuth, "testPass", "accessToken");
 
 			// Then
 			assertAll(
@@ -307,7 +311,7 @@ class MemberServiceTest {
 
 			// When
 			MemberException exception = assertThrows(MemberException.class,
-				() -> memberService.withdraw(memberAuth, "testPass"));
+				() -> memberService.withdraw(memberAuth, "testPass", "accessToken"));
 
 			// Then
 			assertAll(
@@ -330,7 +334,7 @@ class MemberServiceTest {
 
 			// When
 			MemberException exception = assertThrows(MemberException.class,
-				() -> memberService.withdraw(memberAuth, "testPass"));
+				() -> memberService.withdraw(memberAuth, "testPass", "accessToken"));
 
 			// Then
 			assertAll(


### PR DESCRIPTION
transactional로 처리해도 되지만 로그인 시에만 rolse를 조회하기 때문에 rolse를 같이 Fetch하여 조회하도록 수정

로그아웃 시 refresh token 삭제 로직 추가, 탈퇴 시 로그아웃 로직 추가 (transaction이 걸려있기 때문에 로그아웃 실패시 탈퇴가 롤백이 되므로 event를 걸어서 탈퇴 로직이 commit이 된 후 로그아웃이 실행 되도록 하여 로그아웃이 실패해도 탈퇴는 정상 진행 되도록 함)